### PR TITLE
Don't send backspace to the editor

### DIFF
--- a/keymaps/vim-mode.cson
+++ b/keymaps/vim-mode.cson
@@ -1,2 +1,3 @@
 'atom-text-editor.vim-mode':
-  'enter': 'core:cancel' 
+  'enter': 'core:cancel',
+  'backspace': 'core:cancel'


### PR DESCRIPTION
Backspace causes weird behavior because Atom interprets it instead of Neovim
