### PR TITLE
Upgrading Deprecated calls

### DIFF
--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -321,7 +321,7 @@ ns_redraw_win_end = () ->
   qbottom = VimGlobals.current_editor.element.getScrollBottom()
   qrows = Math.floor((qbottom - qtop)/lineSpacing()+1)
 
-  qleft = VimGlobals.current_editor.getScrollLeft()
+  qleft = VimGlobals.current_editor.element.getScrollLeft()
   qright= VimGlobals.current_editor.getScrollRight()
   qcols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1
 
@@ -578,7 +578,7 @@ class EventHandler
 
     atom.setWindowDimensions ('width': 1400, 'height': height)
 
-    qleft = VimGlobals.current_editor.getScrollLeft()
+    qleft = VimGlobals.current_editor.element.getScrollLeft()
     qright= VimGlobals.current_editor.getScrollRight()
 
     @cols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1
@@ -1101,7 +1101,7 @@ class VimState
     qtop = VimGlobals.current_editor.element.getScrollTop()
     qbottom = VimGlobals.current_editor.element.getScrollBottom()
 
-    qleft = VimGlobals.current_editor.getScrollLeft()
+    qleft = VimGlobals.current_editor.element.getScrollLeft()
     qright= VimGlobals.current_editor.getScrollRight()
 
     @cols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -200,7 +200,7 @@ register_change_handler = () ->
 
           #undo_fix = true
 
-          qtop = VimGlobals.current_editor.getScrollTop()
+          qtop = VimGlobals.current_editor.element.getScrollTop()
           qbottom = VimGlobals.current_editor.getScrollBottom()
 
           tln = Math.floor((qtop)/lineSpacing()+1)
@@ -317,7 +317,7 @@ ns_redraw_win_end = () ->
   focused = editor_views[uri].classList.contains('is-focused')
 
 
-  qtop = VimGlobals.current_editor.getScrollTop()
+  qtop = VimGlobals.current_editor.element.getScrollTop()
   qbottom = VimGlobals.current_editor.getScrollBottom()
   qrows = Math.floor((qbottom - qtop)/lineSpacing()+1)
 
@@ -438,7 +438,7 @@ scrollTopChanged = () ->
       else
         up = false
         if scrolltop
-          diff = scrolltop - VimGlobals.current_editor.getScrollTop()
+          diff = scrolltop - VimGlobals.current_editor.element.getScrollTop()
           if diff > 0
             up = false
           else
@@ -463,7 +463,7 @@ scrollTopChanged = () ->
           )
 
   if VimGlobals.current_editor
-    scrolltop = VimGlobals.current_editor.getScrollTop()
+    scrolltop = VimGlobals.current_editor.element.getScrollTop()
 
 
 destroyPaneItem = (event) ->
@@ -566,7 +566,7 @@ activePaneChanged = () ->
 
 class EventHandler
   constructor: (@vimState) ->
-    qtop = VimGlobals.current_editor.getScrollTop()
+    qtop = VimGlobals.current_editor.element.getScrollTop()
     qbottom = VimGlobals.current_editor.getScrollBottom()
 
     @rows = Math.floor((qbottom - qtop)/lineSpacing()+1)
@@ -1098,7 +1098,7 @@ class VimState
     qbottom =0
     @rows = 0
 
-    qtop = VimGlobals.current_editor.getScrollTop()
+    qtop = VimGlobals.current_editor.element.getScrollTop()
     qbottom = VimGlobals.current_editor.getScrollBottom()
 
     qleft = VimGlobals.current_editor.getScrollLeft()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -322,7 +322,7 @@ ns_redraw_win_end = () ->
   qrows = Math.floor((qbottom - qtop)/lineSpacing()+1)
 
   qleft = VimGlobals.current_editor.element.getScrollLeft()
-  qright= VimGlobals.current_editor.getScrollRight()
+  qright= VimGlobals.current_editor.element.getScrollRight()
   qcols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1
 
 
@@ -579,7 +579,7 @@ class EventHandler
     atom.setWindowDimensions ('width': 1400, 'height': height)
 
     qleft = VimGlobals.current_editor.element.getScrollLeft()
-    qright= VimGlobals.current_editor.getScrollRight()
+    qright= VimGlobals.current_editor.element.getScrollRight()
 
     @cols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1
 
@@ -1102,7 +1102,7 @@ class VimState
     qbottom = VimGlobals.current_editor.element.getScrollBottom()
 
     qleft = VimGlobals.current_editor.element.getScrollLeft()
-    qright= VimGlobals.current_editor.getScrollRight()
+    qright= VimGlobals.current_editor.element.getScrollRight()
 
     @cols = Math.floor((qright-qleft)/lineSpacingHorizontal())-1
 

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -201,7 +201,7 @@ register_change_handler = () ->
           #undo_fix = true
 
           qtop = VimGlobals.current_editor.element.getScrollTop()
-          qbottom = VimGlobals.current_editor.getScrollBottom()
+          qbottom = VimGlobals.current_editor.element.getScrollBottom()
 
           tln = Math.floor((qtop)/lineSpacing()+1)
           bot = Math.floor((qbottom )/lineSpacing()+1)
@@ -318,7 +318,7 @@ ns_redraw_win_end = () ->
 
 
   qtop = VimGlobals.current_editor.element.getScrollTop()
-  qbottom = VimGlobals.current_editor.getScrollBottom()
+  qbottom = VimGlobals.current_editor.element.getScrollBottom()
   qrows = Math.floor((qbottom - qtop)/lineSpacing()+1)
 
   qleft = VimGlobals.current_editor.getScrollLeft()
@@ -567,7 +567,7 @@ activePaneChanged = () ->
 class EventHandler
   constructor: (@vimState) ->
     qtop = VimGlobals.current_editor.element.getScrollTop()
-    qbottom = VimGlobals.current_editor.getScrollBottom()
+    qbottom = VimGlobals.current_editor.element.getScrollBottom()
 
     @rows = Math.floor((qbottom - qtop)/lineSpacing()+1)
 
@@ -1099,7 +1099,7 @@ class VimState
     @rows = 0
 
     qtop = VimGlobals.current_editor.element.getScrollTop()
-    qbottom = VimGlobals.current_editor.getScrollBottom()
+    qbottom = VimGlobals.current_editor.element.getScrollBottom()
 
     qleft = VimGlobals.current_editor.getScrollLeft()
     qright= VimGlobals.current_editor.getScrollRight()

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -1077,7 +1077,7 @@ class VimState
               @location[1]),{autoscroll:false})
 
         if VimGlobals.current_editor
-          VimGlobals.current_editor.setScrollTop(lineSpacing()*\
+          VimGlobals.current_editor.element.setScrollTop(lineSpacing()*\
             VimGlobals.tlnumber)
 
       #console.log 'sbr:',sbr

--- a/lib/vim-state.coffee
+++ b/lib/vim-state.coffee
@@ -537,7 +537,8 @@ activePaneChanged = () ->
             VimGlobals.current_editor = atom.workspace.getActiveTextEditor()
             if VimGlobals.current_editor
               scrolltopchange_subscription =
-                VimGlobals.current_editor.onDidChangeScrollTop scrollTopChanged
+                VimGlobals.current_editor.element.onDidChangeScrollTop \
+                    scrollTopChanged
 
               cursorpositionchange_subscription =
                 VimGlobals.current_editor.onDidChangeCursorPosition \

--- a/styles/vim-mode.less
+++ b/styles/vim-mode.less
@@ -22,37 +22,22 @@
 
 atom-text-editor.vim-mode.command-mode,
 atom-text-editor.vim-mode.operator-pending-mode,
-atom-text-editor.vim-mode.visual-mode,
-{
-  &::shadow, // shadow-DOM enabled
-  &           // shadow-DOM disabled
-  {
+atom-text-editor.vim-mode.visual-mode {
     .cursor, .cursor.blink-off {
-      .block-cursor(hidden);
+        .block-cursor(hidden);
     }
-  }
 }
 
 atom-text-editor.vim-mode.command-mode.is-focused,
 atom-text-editor.vim-mode.operator-pending-mode.is-focused,
-atom-text-editor.vim-mode.visual-mode.is-focused
-{
-  &::shadow, // shadow-DOM enabled
-  &           // shadow-DOM disabled
-  {
+atom-text-editor.vim-mode.visual-mode.is-focused {
     .cursor, .cursor.blink-off {
-      .block-cursor;
+        .block-cursor;
     }
-  }
 }
 
-atom-text-editor.vim-mode.visual-mode
-{
-  &::shadow, // shadow-DOM enabled
-  &           // shadow-DOM disabled
-  {
+atom-text-editor.vim-mode.visual-mode {
     .cursor.hidden-cursor {
-      display: block;
+        display: block;
     }
-  }
 }


### PR DESCRIPTION
This upgrades all deprecated calls. Basically, all these calls that used to be done on the text editor instance is now done on the text editor element instead.

Furthermore, some HTML elements are no longer exposed to the shadow dom. This fixes that.