### PR TITLE
Encapsulate nvim Session logic and Embed nvim into atom

### DIFF
--- a/lib/vim-globals.coffee
+++ b/lib/vim-globals.coffee
@@ -3,10 +3,6 @@ root = exports ? this
 unless root.lupdates
   root.lupdates = []
 
-unless root.session
-  root.session = undefined
-
-
 unless root.current_editor
   root.current_editor = undefined
 

--- a/lib/vim-mode.coffee
+++ b/lib/vim-mode.coffee
@@ -4,6 +4,13 @@
 VimState = require './vim-state'
 
 module.exports =
+  config:
+    embed:
+      type: 'boolean'
+      default: false
+  "neovim-path":
+    type: 'string'
+    default: '/usr/local/bin/nvim'
 
   activate: ->
 

--- a/lib/vim-neovim-session.coffee
+++ b/lib/vim-neovim-session.coffee
@@ -1,0 +1,87 @@
+
+MsgPack = require 'msgpack5rpc'
+os = require 'os'
+net = require 'net'
+
+if os.platform() is 'win32'
+  CONNECT_TO = '\\\\.\\pipe\\neovim'
+else
+  CONNECT_TO = '/tmp/neovim/neovim'
+
+socket2 = new net.Socket()
+socket2.connect(CONNECT_TO)
+socket2.on('error', (error) ->
+  console.log 'error communicating (send message): ' + error
+  socket2.destroy()
+)
+tmpsession = new MsgPack()
+tmpsession.attach(socket2, socket2)
+
+class RBuffer
+  constructor:(data) ->
+    @data = data
+
+class RWindow
+  constructor:(data) ->
+    @data = data
+
+class RTabpage
+  constructor:(data) ->
+    @data = data
+
+types = []
+
+# Actual persisted session
+session = undefined
+
+tmpsession.request('vim_get_api_info', [], (err, res) ->
+  metadata = res[1]
+  constructors = [
+      RBuffer
+      RWindow
+      RTabpage
+  ]
+  i = 0
+  l = constructors.length
+  while i < l
+    ((constructor) ->
+      types.push
+        constructor: constructor
+        code: metadata.types[constructor.name[1..]].id
+        decode: (data) ->
+          new constructor(data)
+        encode: (obj) ->
+          obj.data
+      return
+    ) constructors[i]
+    i++
+
+
+  tmpsession.detach()
+  socket = new net.Socket()
+  socket.connect(CONNECT_TO)
+
+  session = new MsgPack(types)
+  session.attach(socket, socket)
+)
+
+module.exports = {
+  sendMessage: (message,f = undefined) ->
+    try
+      if message[0] and message[1]
+        session.request(message[0], message[1], (err, res) ->
+          if f
+            if typeof(res) is 'number'
+              f(util.inspect(res))
+            else
+              f(res)
+        )
+    catch err
+      console.log 'error in neovim_send_message '+err
+      console.log 'm1:',message[0]
+      console.log 'm2:',message[1]
+
+  addNotificationListener: (callback) ->
+    session.on('notification', callback)
+}
+

--- a/lib/vim-neovim-session.coffee
+++ b/lib/vim-neovim-session.coffee
@@ -10,19 +10,17 @@ socket_address = () ->
   else
     '/tmp/neovim/neovim'
 
-# todo: move this to options
-EMBED = false
 nvim_proc = undefined
 
 input = undefined
 output = undefined
 
-if EMBED
-  # todo: the path should be part of options
+if atom.config.get('vim-mode.embed')
   nvim_proc = cp.spawn(
-    '/usr/local/bin/nvim',
+    atom.config.get('vim-mode.neovim-path'),
     ['--embed', '-u', 'NONE', '-N'],
     {})
+  console.log('Spawning nvim instance')
   input = nvim_proc.stdin
   output = nvim_proc.stdout
 else
@@ -32,6 +30,7 @@ else
     console.log 'error communicating (send message): ' + error
     tmp_socket.destroy()
   )
+  console.log('Connecting to existing nvim instance')
   input = tmp_socket
   output = tmp_socket
 
@@ -79,7 +78,7 @@ tmpsession.request('vim_get_api_info', [], (err, res) ->
 
   tmpsession.detach()
 
-  if !EMBED
+  if !atom.config.get('vim-mode.embed')
     socket = new net.Socket()
     socket.connect(socket_address())
     input = socket

--- a/lib/vim-neovim-session.coffee
+++ b/lib/vim-neovim-session.coffee
@@ -4,13 +4,14 @@ os = require 'os'
 net = require 'net'
 cp = require 'child_process'
 
-if os.platform() is 'win32'
-  CONNECT_TO = '\\\\.\\pipe\\neovim'
-else
-  CONNECT_TO = '/tmp/neovim/neovim'
+socket_address = () ->
+  if os.platform() is 'win32'
+    '\\\\.\\pipe\\neovim'
+  else
+    '/tmp/neovim/neovim'
 
 # todo: move this to options
-EMBED = true
+EMBED = false
 nvim_proc = undefined
 
 input = undefined
@@ -26,7 +27,7 @@ if EMBED
   output = nvim_proc.stdout
 else
   tmp_socket = new net.Socket()
-  tmp_socket.connect(CONNECT_TO)
+  tmp_socket.connect(socket_address())
   tmp_socket.on('error', (error) ->
     console.log 'error communicating (send message): ' + error
     tmp_socket.destroy()
@@ -80,7 +81,7 @@ tmpsession.request('vim_get_api_info', [], (err, res) ->
 
   if !EMBED
     socket = new net.Socket()
-    socket.connect(CONNECT_TO)
+    socket.connect(socket_address())
     input = socket
     output = socket
 


### PR DESCRIPTION
This pull request does a few things:
1) It separates out all the logic needed to create and maintain sessions with nvim into its own module
2) It allows nvim to be spawed by the vim-mode extension itself.
3) It give us the option of communicating with nvim via stdin/stdout
4) opens nvim to some basic configs via config.cson


Option 3 is really what I was after. I have some more changes on the way that'll utilize stdin/out